### PR TITLE
Copy releases/catalog.js to scittelts/

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -40,24 +40,23 @@ jobs:
 
       - name: Verify tag is setup in both releases/tags.txt and releases/catalog.json
         run: |
-          TAG_VERSION=$(jq -r .release.tag_name "$GITHUB_EVENT_PATH")
           FILE="releases/tags.txt"
           FILE_VERSION=$(head -n 1 $FILE | tr -d '\r')
 
           # Verify tag version matches first line of releases/tags.txt
-          if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
-            echo "Error: Tag version ($TAG_VERSION) does not match $FILE first line ($FILE_VERSION)"
+          if [ "$TAG_NAME" != "$FILE_VERSION" ]; then
+            echo "Error: Tag version ($TAG_NAME) does not match $FILE first line ($FILE_VERSION)"
             exit 1
           else
-            echo "Version match confirmed: $TAG_VERSION"
+            echo "Version match confirmed: $TAG_NAME"
           fi
 
           # Verify tag version matches version in releases/catalog.json
-          if ! grep -q "\"version\" *: *\"$TAG_VERSION\"" releases/catalog.json; then
-            echo "Error: version \"$TAG_VERSION\" not found in releases/catalog.json"
+          if ! grep -q "\"version\" *: *\"$TAG_NAME\"" releases/catalog.json; then
+            echo "Error: version \"$TAG_NAME\" not found in releases/catalog.json"
             exit 1
           else
-            echo "Version match found in releases/catalog.json: $TAG_VERSION"
+            echo "Version match found in releases/catalog.json: $TAG_NAME"
           fi
 
       - name: rebase
@@ -84,6 +83,10 @@ jobs:
 
           # use updated catalog to update HTML files deps in TARGET
           cat releases/catalog.json
+          # TODO: this is needed from API pages to source the
+          # dependnecies dependencies. The API pages should construct
+          # the jsdelivr URL based on the version instead.
+          cp releases/catalog.json scittelts/catalog.json
           npm run updateLocalHtmlFiles releases/catalog.json $TARGET
 
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased Catalog
 
+* Release script now copies `catalog.json` from local `releases/` to `scittlets/` on GitHub Pages for API dependency display, correcting an omission in the previous release (#25)
+
 ## Unreleased CLI
 
 ## cli-v0.8.0

--- a/test/scittlets/reagent/test_utils.cljs
+++ b/test/scittlets/reagent/test_utils.cljs
@@ -12,7 +12,7 @@
                 (.then (fn [res]
                          (println :fetching/response url)
                          (if-not (.-ok res)
-                           (throw (str "HTTP error: status " (.-status res) " url " url))
+                           (throw (js/Error. (str "HTTP error: status " (.-status res) " url " url)))
                            (.text res))))
                 (.then (fn [text]
                          (println :fetching/text url)


### PR DESCRIPTION
The API pages rely on catalog.json to be at the root of `scittlets/` to display dependencies